### PR TITLE
Remove vue-loader info from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,3 @@ npm run unit
 # run all tests
 npm test
 ```
-
-For detailed explanation on how things work, checkout the [guide](http://vuejs-templates.github.io/webpack/) and [docs for vue-loader](http://vuejs.github.io/vue-loader).


### PR DESCRIPTION
I believe it shouldn't be there.